### PR TITLE
fix for division by zero error

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -62,7 +62,12 @@ class Product(SafeDeleteModel):
         for rating in ratings:
             total_rating += rating.rating
 
-        avg = total_rating / len(ratings)
+        # If there are no ratings, then the average will be set to 0
+        try:
+            avg = total_rating / len(ratings)
+        except ZeroDivisionError:
+            avg = total_rating
+
         return avg
 
     class Meta:


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- Added a try/except around the average calculation.  This catches the `ZeroDivisionError`. If there are no ratings, it sets the average rating to 0.


## Testing

Description of how to test code...

- [ ] Seed database and Run migrations
- [ ] Submit `GET` request to `/profile/cart`
- [ ] Receive correct call back; avoiding `ZeroDivisionError`


## Related Issues

- Fixes #11 