### PR TITLE
Md min product sold

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -266,7 +266,7 @@ class Products(ViewSet):
 
         if number_sold is not None:
             def sold_filter(product):
-                if product.number_sold <= int(number_sold):
+                if product.number_sold >= int(number_sold):
                     return True
                 return False
 


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- Issue was caused by filtering for `product.number_sold <= int(number_sold)`; resolved by changing query to `product.number_sold >= int(number_sold)`

## Requests / Responses

**Request**

`GET` `/products?number_sold=1` returns products with at least 1 item sold.

**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 45,
        "name": "Corvette",
        "price": 795.8,
        "number_sold": 1,
        "description": "1987 Chevrolet",
        "quantity": 2,
        "created_date": "2019-10-07",
        "location": "Ueno",
        "image_path": null,
        "average_rating": 0
    },
    {
        "id": 50,
        "name": "Escalade EXT",
        "price": 926.92,
        "number_sold": 2,
        "description": "2008 Cadillac",
        "quantity": 2,
        "created_date": "2019-02-01",
        "location": "Lokavec",
        "image_path": null,
        "average_rating": 3.25
    }
]
```

## Related Issues

- Fixes #5 