### PR TITLE
paymenttype view now only shows auth user payment types

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -81,7 +81,7 @@ class Payments(ViewSet):
         """Handle GET requests to payment type resource"""
         payment_types = Payment.objects.all()
 
-        customer_id = self.request.query_params.get('customer', None)
+        customer_id = self.request.auth.user.id
 
         if customer_id is not None:
             payment_types = payment_types.filter(customer__id=customer_id)


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- updated list method on `paymenttype` view to return only the authenticated user's payment types

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

`GET` `/paymenttypes` requests a list of the auth'd user's payment types

**Response**

HTTP/1.1 200 SUCCESS

```json
    {
        "id": 1,
        "url": "http://localhost:8000/paymenttypes/1",
        "merchant_name": "Visa",
        "account_number": "24ijio68948fj8439",
        "expiration_date": "2020-01-01",
        "create_date": "2019-11-11"
    }
```

## Testing

Description of how to test code...

- [ ] GET request on /paymenttypes

## Related Issues

- Fixes #8