### PR TITLE
items no long post to closed order

### DIFF
--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -104,7 +104,7 @@ class Orders(ViewSet):
         """
         customer = Customer.objects.get(user=request.auth.user)
         order = Order.objects.get(pk=pk, customer=customer)
-        order.payment_type = request.data["payment_type"]
+        order.payment_type = Payment.objects.get(pk=request.data["payment_type"])
         order.save()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -206,7 +206,7 @@ class Profile(ViewSet):
             """
 
             try:
-                open_order = Order.objects.get(customer=current_user)
+                open_order = Order.objects.get(customer=current_user, payment_type__isnull=True)
                 print(open_order)
             except Order.DoesNotExist as ex:
                 open_order = Order()


### PR DESCRIPTION
## Changes

- Added filter in `views/profile` for `Order.objects.get` where `payment_type` must be null.

## Requests / Responses

**Request**

`POST` `/profile/cart`

```json
{
    "product_id": 13
}
```

**Response**

HTTP/1.1 200 OK

```json
{
    "id": 11,
    "product": {
        "id": 13,
        "name": "Express 3500",
        "price": 714.78,
        "number_sold": 0,
        "description": "2003 Chevrolet",
        "quantity": 2,
        "created_date": "2019-01-02",
        "location": "Cabo",
        "image_path": null,
        "average_rating": 0
    }
}
```

## Related Issues

- Fixes #3 