### PR TITLE
able to delete lineitems

### DIFF
--- a/bangazonapi/views/lineitem.py
+++ b/bangazonapi/views/lineitem.py
@@ -77,7 +77,7 @@ class LineItems(ViewSet):
         try:
             customer = Customer.objects.get(user=request.auth.user)
             order_product = OrderProduct.objects.get(pk=pk, order__customer=customer)
-
+            order_product.delete()
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 
         except OrderProduct.DoesNotExist as ex:


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- Added missing `order_product.delete()` to `destroy` function in `views/lineitem.py`

## Requests / Responses

**Request**

`DELETE` `/lineitems/:id` deletes specified `lineitem`


**Response**

HTTP/1.1 204 NO CONTENT

## Testing

Description of how to test code...

- [ ] Add a product to cart by sending a `POST` request on `profile/cart`
- [ ] Perform a `DELETE` request at `lineitems/:id` to delete specified `lineitem`



## Related Issues

- Fixes #6 