### PR TITLE
corrected create/expiration date error

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -34,8 +34,8 @@ class Payments(ViewSet):
         new_payment = Payment()
         new_payment.merchant_name = request.data["merchant_name"]
         new_payment.account_number = request.data["account_number"]
-        new_payment.expiration_date = request.data["create_date"]
-        new_payment.create_date = request.data["expiration_date"]
+        new_payment.expiration_date = request.data["expiration_date"]
+        new_payment.create_date = request.data["create_date"]
         customer = Customer.objects.get(user=request.auth.user)
         new_payment.customer = customer
         new_payment.save()


### PR DESCRIPTION
## Changes

- In the `create` method of `/views/paymenttype`, corrected the inverse lines where `expiration_date` was set to `creation_date` and vice versa.


## Requests / Responses

**Request**

`POST` `/paymenttypes`

```json
{
    "merchant_name": "Visa",
    "account_number": "000000000000",
    "expiration_date": "2025-01-02",
    "create_date": "2020-01-02"
}
```

**Response**

HTTP/1.1 201 CREATED

```json
{
    "id": 4,
    "url": "http://localhost:8000/paymenttypes/4",
    "merchant_name": "Visa",
    "account_number": "000000000000",
    "expiration_date": "2025-01-02",
    "create_date": "2020-01-02"
}
```

## Testing

- [ ] Run `POST` method on `/paymenttypes` to create a new payment type
- [ ] Confirm that the response body matches what was requested


## Related Issues

- Fixes #7 