### PR TITLE
added query that filters by min_price

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -248,6 +248,7 @@ class Products(ViewSet):
         order = self.request.query_params.get('order_by', None)
         direction = self.request.query_params.get('direction', None)
         number_sold = self.request.query_params.get('number_sold', None)
+        min_price = self.request.query_params.get('min_price', None)
 
         if order is not None:
             order_filter = order
@@ -271,6 +272,14 @@ class Products(ViewSet):
                 return False
 
             products = filter(sold_filter, products)
+            
+        if min_price is not None:
+            def price_filter(product):
+                if product.price >= float(min_price):
+                    return True
+                return False
+
+            products = filter(price_filter, products)
 
         serializer = ProductSerializer(
             products, many=True, context={'request': request})


### PR DESCRIPTION
## Changes

- Added `min_price` filter in `views/product`

## Requests / Responses



**Request**

`GET` `/products?min_price=1910`

**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 32,
        "name": "DB9",
        "price": 1912.51,
        "number_sold": 0,
        "description": "2008 Aston Martin",
        "quantity": 3,
        "created_date": "2019-01-06",
        "location": "Paris 07",
        "image_path": null,
        "average_rating": 0
    },
    {
        "id": 41,
        "name": "Impreza",
        "price": 1913.81,
        "number_sold": 0,
        "description": "1998 Subaru",
        "quantity": 4,
        "created_date": "2019-03-15",
        "location": "Dingjiaqiao",
        "image_path": null,
        "average_rating": 0
    },
    {
        "id": 60,
        "name": "Elantra",
        "price": 1989.84,
        "number_sold": 0,
        "description": "1994 Hyundai",
        "quantity": 1,
        "created_date": "2019-01-19",
        "location": "Sosnovoborsk",
        "image_path": null,
        "average_rating": 0
    }
]
```

## Testing


- [ ] Run run query `/products?min_price=` with the value of the query being what you want to filter by
- [ ] Confirm response is filtered by the entered query.

## Related Issues

- Fixes #9