### PR TITLE
added ability to filter by product location

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -259,6 +259,7 @@ class Products(ViewSet):
         direction = self.request.query_params.get('direction', None)
         number_sold = self.request.query_params.get('number_sold', None)
         min_price = self.request.query_params.get('min_price', None)
+        location = self.request.query_params.get('location', None)
 
         if order is not None:
             order_filter = order
@@ -290,6 +291,9 @@ class Products(ViewSet):
                 return False
 
             products = filter(price_filter, products)
+
+        if location is not None:
+            products = products.filter(location__contains=location)
 
         serializer = ProductSerializer(
             products, many=True, context={'request': request})


### PR DESCRIPTION
## Changes

- Added location query filter to `/views/product` that posts results where the location contains the query

## Requests / Responses

**Request**

`GET` `/products?location=sant`


**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 4,
        "name": "H1",
        "price": 1448.54,
        "number_sold": 0,
        "description": "2004 Hummer",
        "quantity": 3,
        "created_date": "2019-05-24",
        "location": "Santa Maria",
        "image_path": null,
        "average_rating": 0
    },
    {
        "id": 86,
        "name": "1500 Club Coupe",
        "price": 676.11,
        "number_sold": 0,
        "description": "1997 GMC",
        "quantity": 2,
        "created_date": "2019-07-26",
        "location": "Santo Tomas",
        "image_path": null,
        "average_rating": 0
    },
    {
        "id": 98,
        "name": "Explorer Sport Trac",
        "price": 1611.83,
        "number_sold": 0,
        "description": "2000 Ford",
        "quantity": 4,
        "created_date": "2019-01-05",
        "location": "Santa Praxedes",
        "image_path": null,
        "average_rating": 0
    }
]
```

## Testing


- [ ] Run `GET` request for `products` with the query of location; `/products?location=`
- [ ] Confirm results match the queried location



## Related Issues

- Fixes #12 