### PR TITLE
added function to favorite a seller

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -226,7 +226,7 @@ class Profile(ViewSet):
 
         return Response({}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
-    @action(methods=['get'], detail=False)
+    @action(methods=['get', 'post'], detail=False)
     def favoritesellers(self, request):
         """
         @api {GET} /profile/favoritesellers GET favorite sellers
@@ -277,9 +277,21 @@ class Profile(ViewSet):
         customer = Customer.objects.get(user=request.auth.user)
         favorites = Favorite.objects.filter(customer=customer)
 
+        if request.method == "POST":
+            favorite_seller = Favorite()
+            favorite_seller.seller = Customer.objects.get(pk=request.data["seller"])
+            favorite_seller.customer = customer
+            favorite_seller.save()
+
+            favorite_seller_json = FavoriteSerializer(favorite_seller, many=False, context={'request': request})
+
+            return Response(favorite_seller_json.data)
+
         serializer = FavoriteSerializer(
             favorites, many=True, context={'request': request})
         return Response(serializer.data)
+
+        return Response({}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
 
 class LineItemSerializer(serializers.HyperlinkedModelSerializer):

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -291,7 +291,7 @@ class Profile(ViewSet):
             favorites, many=True, context={'request': request})
         return Response(serializer.data)
 
-        return Response({}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
+    return Response({}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
 
 class LineItemSerializer(serializers.HyperlinkedModelSerializer):

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -274,10 +274,17 @@ class Profile(ViewSet):
                 }
             ]
         """
-        customer = Customer.objects.get(user=request.auth.user)
-        favorites = Favorite.objects.filter(customer=customer)
+
+        if request.method == "GET":
+            customer = Customer.objects.get(user=request.auth.user)
+            favorites = Favorite.objects.filter(customer=customer)
+
+            serializer = FavoriteSerializer(
+                favorites, many=True, context={'request': request})
+            return Response(serializer.data)
 
         if request.method == "POST":
+            customer = Customer.objects.get(user=request.auth.user)
             favorite_seller = Favorite()
             favorite_seller.seller = Customer.objects.get(pk=request.data["seller"])
             favorite_seller.customer = customer
@@ -287,11 +294,7 @@ class Profile(ViewSet):
 
             return Response(favorite_seller_json.data)
 
-        serializer = FavoriteSerializer(
-            favorites, many=True, context={'request': request})
-        return Response(serializer.data)
-
-    return Response({}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
+        return Response({}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
 
 class LineItemSerializer(serializers.HyperlinkedModelSerializer):


### PR DESCRIPTION
## Changes

- Added `POST` method to `favoritesellers` in `views/profile` that gives server functionality to favorite a seller


## Requests / Responses



**Request**

POST `/products` Creates a new product

```json
{
   "seller": 7
}
```

**Response**

HTTP/1.1 200 OK

```json
{
    "id": 5,
    "seller": {
        "id": 7,
        "url": "http://localhost:8000/customers/7",
        "user": {
            "first_name": "Brenda",
            "last_name": "Matthews",
            "username": "brenda"
        }
    }
}
```

## Testing


- [ ] Run `POST` request on `/profile/favoritesellers`
- [ ] Run `GET` request on `/profile/favoritesellers` to verify it posted


## Related Issues

- Fixes #13 