### PR TITLE
added test to delete products

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -165,6 +165,8 @@ class Products(ViewSet):
             product = Product.objects.get(pk=pk)
             serializer = ProductSerializer(product, context={'request': request})
             return Response(serializer.data)
+        except Product.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
         except Exception as ex:
             return HttpResponseServerError(ex)
 

--- a/tests/product.py
+++ b/tests/product.py
@@ -95,6 +95,21 @@ class ProductTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(json_response), 3)
 
-    # TODO: Delete product
+    def test_delete_product(self):
+        """
+        Ensure we can delete a product
+        """
+        # Create a product to test deletion
+        self.test_create_product()
+
+        # Delete the newly created product
+        url = '/products/1'
+        response = self.client.delete(url, None, format='json')
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # Try to GET deleted product to confirm deletion
+        url = '/products/1'
+        response = self.client.get(url, None, format='json')
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     # TODO: Product can be rated. Assert average rating exists.


### PR DESCRIPTION
## Changes

- Added `test_delete_product` to `/tests/product`
- Added `except` block to `/views/product` in `retrieve` to return a `HTTP_404_NOT_FOUND` response if the product doesn't exist instead of just a `HttpResponseServerError`


## Testing

- [ ] Run `./seed_data.sh` to migrate and seed database
- [ ] Run `python manage.py test tests`


## Related Issues

- Fixes #18 